### PR TITLE
Use cmake to explicitly select MSYS Makefiles under mingw64/32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # Other
 Cargo.lock
 *.log
+*~

--- a/hbs-acc-pow-sys/build.rs
+++ b/hbs-acc-pow-sys/build.rs
@@ -19,9 +19,19 @@ fn main() {
                                 src.join("cmake-toolchain").join("android.toolchain.cmake").display()),
                 false => "".to_owned(),
             };
+            let cmake_gen = match env::var("MSYSTEM") {
+                Ok(val) => {
+                    if val.contains("MINGW") {
+                        "-GMSYS Makefiles".to_owned()
+                    } else {
+                        "".to_owned()
+                    }
+                },
+                Err(_) => "".to_owned(),
+            };
             fs::remove_dir_all(&build).ok();
             fs::create_dir_all(&build).unwrap();
-            run(Command::new("cmake").arg(cmake_var).arg(src.to_str().unwrap()).current_dir(&build));
+            run(Command::new("cmake").arg(cmake_var).arg(cmake_gen).arg(src.to_str().unwrap()).current_dir(&build));
             run(Command::new("make").arg("hbs-acc-pow-static").current_dir(&build));
             println!("cargo:rustc-link-lib=static=hbs-acc-pow-static");
             println!("cargo:rustc-link-search=native={}", build.join("lib").display());

--- a/hbs-acc-sys/build.rs
+++ b/hbs-acc-sys/build.rs
@@ -19,9 +19,19 @@ fn main() {
                                 src.join("cmake-toolchain").join("android.toolchain.cmake").display()),
                 false => "".to_owned(),
             };
+            let cmake_gen = match env::var("MSYSTEM") {
+                Ok(val) => {
+                    if val.contains("MINGW") {
+                        "-GMSYS Makefiles".to_owned()
+                    } else {
+                        "".to_owned()
+                    }
+                },
+                Err(_) => "".to_owned(),
+            };
             fs::remove_dir_all(&build).ok();
             fs::create_dir_all(&build).unwrap();
-            run(Command::new("cmake").arg(cmake_var).arg(src.to_str().unwrap()).current_dir(&build));
+            run(Command::new("cmake").arg(cmake_var).arg(cmake_gen).arg(src.to_str().unwrap()).current_dir(&build));
             run(Command::new("make").arg("hbs-acc-static").current_dir(&build));
             println!("cargo:rustc-link-lib=static=hbs-acc-static");
             println!("cargo:rustc-link-search=native={}", build.join("lib").display());

--- a/hbs-pow-sys/build.rs
+++ b/hbs-pow-sys/build.rs
@@ -19,9 +19,19 @@ fn main() {
                                 src.join("cmake-toolchain").join("android.toolchain.cmake").display()),
                 false => "".to_owned(),
             };
+            let cmake_gen = match env::var("MSYSTEM") {
+                Ok(val) => {
+                    if val.contains("MINGW") {
+                        "-GMSYS Makefiles".to_owned()
+                    } else {
+                        "".to_owned()
+                    }
+                },
+                Err(_) => "".to_owned(),
+            };
             fs::remove_dir_all(&build).ok();
             fs::create_dir_all(&build).unwrap();
-            run(Command::new("cmake").arg(cmake_var).arg(src.to_str().unwrap()).current_dir(&build));
+            run(Command::new("cmake").arg(cmake_var).arg(cmake_gen).arg(src.to_str().unwrap()).current_dir(&build));
             run(Command::new("make").arg("hbs-pow-static").current_dir(&build));
             println!("cargo:rustc-link-lib=static=hbs-pow-static");
             println!("cargo:rustc-link-search=native={}", build.join("lib").display());

--- a/hbs-sys/build.rs
+++ b/hbs-sys/build.rs
@@ -19,9 +19,19 @@ fn main() {
                                 src.join("cmake-toolchain").join("android.toolchain.cmake").display()),
                 false => "".to_owned(),
             };
+            let cmake_gen = match env::var("MSYSTEM") {
+                Ok(val) => {
+                    if val.contains("MINGW") {
+                        "-GMSYS Makefiles".to_owned()
+                    } else {
+                        "".to_owned()
+                    }
+                },
+                Err(_) => "".to_owned(),
+            };
             fs::remove_dir_all(&build).ok();
             fs::create_dir_all(&build).unwrap();
-            run(Command::new("cmake").arg(cmake_var).arg(src.to_str().unwrap()).current_dir(&build));
+            run(Command::new("cmake").arg(cmake_var).arg(cmake_gen).arg(src.to_str().unwrap()).current_dir(&build));
             run(Command::new("make").arg("hbs-static").current_dir(&build));
             println!("cargo:rustc-link-lib=static=hbs-static");
             println!("cargo:rustc-link-search=native={}", build.join("lib").display());


### PR DESCRIPTION
When building under mingw64 (such as for Servo), we want MSYS Makefiles to be generated, and not visual studio projects as would be the default for cmake.
